### PR TITLE
(docs) Update migration guide with an extra step related to dynamic imports

### DIFF
--- a/pages/docs/migration-guide.en-US.mdx
+++ b/pages/docs/migration-guide.en-US.mdx
@@ -578,13 +578,38 @@ Remove the following metadata:
 - The `sharedOnlineOfflineProps` object
 - The `export` statement at the bottom of the file
 
-### Final `index.ts` file
+### 6. Tweak component imports to limit the number of Webpack chunks created
 
-Bringing all these changes together, we get the following `index.ts` file:
+<Callout emoji="ℹ️" type="info">
+  This is a recent performance optimization that has been shown to reduce the number of JavaScript files loaded at runtime significantly.
+</Callout>
+
+From the optimizations suggested above, we've learned that we can reduce the number of Webpack chunks created by importing components directly instead of importing them via a function call. For example, instead of doing this:
+
+```ts
+export const root = getAsyncLifecycle(() => import("./root.component"), options);
+```
+
+We can do this:
+
+```ts
+import rootComponent from './root.component';
+
+export const root = getSyncLifecycle(rootComponent, options);
+```
+
+This is because the `getAsyncLifecycle` function is only necessary when we need to dynamically import a component. In this case, we're importing the component directly, so we can use the `getSyncLifecycle` function instead. The way Webpack's chunking algorithm works is that, loosely, each time we create a dynamic import like `getAsyncLifecycle(() => import('./some-file')))`, Webpack creates a new "chunk" for that file. This means that if we have 10 dynamic imports in a file, Webpack will create 10 chunks. This is not ideal because it means that we're loading 10 chunks at runtime, which has a performance impact. To avoid this, we can import the components directly and use the `getSyncLifecycle` function instead. We've tested this out and we've seen a marked performance benefit from doing so.
+
+Going back to the Login example, we can tweak the component imports as follows:
 
 ```ts
 import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
+
+import rootComponent from "./root.component";
+import locationPickerComponent from "./location-picker/location-picker.component";
+import logoutButtonComponent from "./logout/logout.component";
+import changeLocationLinkComponent from "./change-location-link/change-location-link.component";
 
 const moduleName = "@openmrs/esm-login-app";
 
@@ -599,14 +624,52 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const root = getAsyncLifecycle(() => import("./root.component"), options);
+export const root = getSyncLifecycle(rootComponent, options);
 
-export const locationPicker = getAsyncLifecycle(() => import("./location-picker/location-picker.component"), options);
+export const locationPicker = getSyncLifecycle(locationPickerComponent, options);
 
-export const logoutButton = getAsyncLifecycle(() => import("./logout/logout.component"), options);
+export const logoutButton = getSyncLifecycle(logoutButtonComponent, options);
 
-export const changeLocationLink = getAsyncLifecycle(
-  () => import("./change-location-link/change-location-link.component"),
+export const changeLocationLink = getSyncLifecycle(
+  changeLocationLinkComponent,
+  options
+);
+```
+
+### Final `index.ts` file
+
+Bringing all these changes together, we get the following `index.ts` file:
+
+```ts
+import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
+import { configSchema } from "./config-schema";
+
+import rootComponent from "./root.component";
+import locationPickerComponent from "./location-picker/location-picker.component";
+import logoutButtonComponent from "./logout/logout.component";
+import changeLocationLinkComponent from "./change-location-link/change-location-link.component";
+
+const moduleName = "@openmrs/esm-login-app";
+
+const options = {
+  featureName: "login",
+  moduleName,
+};
+
+export const importTranslation = require.context("../translations", false, /.json$/, "lazy");
+
+export function startupApp() {
+  defineConfigSchema(moduleName, configSchema);
+}
+
+export const root = getSyncLifecycle(rootComponent, options);
+
+export const locationPicker = getSyncLifecycle(locationPickerComponent, options);
+
+export const logoutButton = getSyncLifecycle(logoutButtonComponent, options);
+
+export const changeLocationLink = getSyncLifecycle(
+  changeLocationLinkComponent,
   options
 );
 ```

--- a/pages/docs/migration-guide.fr-FR.mdx
+++ b/pages/docs/migration-guide.fr-FR.mdx
@@ -507,13 +507,38 @@ Supprimez les métadonnées suivantes:
 - L'objet `sharedOnlineOfflineProps`.
 - La déclaration `export` au bas du fichier
 
-### Fichier `index.ts` final
+### 6. Ajuster les importations de composants pour limiter le nombre de chunks Webpack créés
 
-En rassemblant tous ces changements, nous obtenons le fichier `index.ts` suivant:
+<Callout emoji="ℹ️" type="info">
+  Il s'agit d'une optimisation récente des performances qui a permis de réduire considérablement le nombre de fichiers JavaScript chargés au moment de l'exécution.
+</Callout>
+
+Les optimisations proposées ci-dessus nous ont appris qu'il est possible de réduire le nombre de chunks Webpack créés en important directement les composants au lieu de les importer via un appel de fonction. Par exemple, au lieu de faire ceci:
+
+```ts
+export const root = getAsyncLifecycle(() => import("./root.component"), options);
+```
+
+Nous pouvons faire ceci:
+
+```ts
+import rootComponent from './root.component' ;
+
+export const root = getSyncLifecycle(rootComponent, options) ;
+```
+
+En effet, la fonction `getAsyncLifecycle` n'est nécessaire que lorsque nous devons importer dynamiquement un composant. Dans ce cas, nous importons le composant directement, donc nous pouvons utiliser la fonction `getSyncLifecycle` à la place. La façon dont l'algorithme de découpage de Webpack fonctionne est que, en gros, chaque fois que nous créons un import dynamique comme `getAsyncLifecycle() => import('./some-file')))`, Webpack crée un nouveau "chunk" pour ce fichier. Cela signifie que si nous avons 10 importations dynamiques dans un fichier, Webpack créera 10 chunks. Ce n'est pas idéal car cela signifie que nous chargeons 10 chunks à l'exécution, ce qui a un impact sur les performances. Pour éviter cela, nous pouvons importer les composants directement et utiliser la fonction `getSyncLifecycle` à la place. Nous avons testé cette méthode et nous avons constaté un net gain de performance.
+
+Pour revenir à l'exemple de la connexion, nous pouvons modifier les importations de composants comme suit:
 
 ```ts
 import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
+
+import rootComponent from "./root.component";
+import locationPickerComponent from "./location-picker/location-picker.component";
+import logoutButtonComponent from "./logout/logout.component";
+import changeLocationLinkComponent from "./change-location-link/change-location-link.component";
 
 const moduleName = "@openmrs/esm-login-app";
 
@@ -528,14 +553,51 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const root = getAsyncLifecycle(() => import("./root.component"), options);
+export const root = getSyncLifecycle(rootComponent, options);
 
-export const locationPicker = getAsyncLifecycle(() => import("./location-picker/location-picker.component"), options);
+export const locationPicker = getSyncLifecycle(locationPickerComponent, options);
 
-export const logoutButton = getAsyncLifecycle(() => import("./logout/logout.component"), options);
+export const logoutButton = getSyncLifecycle(logoutButtonComponent, options);
 
-export const changeLocationLink = getAsyncLifecycle(
-  () => import("./change-location-link/change-location-link.component"),
+export const changeLocationLink = getSyncLifecycle(
+  changeLocationLinkComponent,
+  options
+);
+```
+### Fichier `index.ts` final
+
+En rassemblant tous ces changements, nous obtenons le fichier `index.ts` suivant:
+
+```ts
+import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
+import { configSchema } from "./config-schema";
+
+import rootComponent from "./root.component";
+import locationPickerComponent from "./location-picker/location-picker.component";
+import logoutButtonComponent from "./logout/logout.component";
+import changeLocationLinkComponent from "./change-location-link/change-location-link.component";
+
+const moduleName = "@openmrs/esm-login-app";
+
+const options = {
+  featureName: "login",
+  moduleName,
+};
+
+export const importTranslation = require.context("../translations", false, /.json$/, "lazy");
+
+export function startupApp() {
+  defineConfigSchema(moduleName, configSchema);
+}
+
+export const root = getSyncLifecycle(rootComponent, options);
+
+export const locationPicker = getSyncLifecycle(locationPickerComponent, options);
+
+export const logoutButton = getSyncLifecycle(logoutButtonComponent, options);
+
+export const changeLocationLink = getSyncLifecycle(
+  changeLocationLinkComponent,
   options
 );
 ```
@@ -550,8 +612,8 @@ yarn up openmrs@next @openmrs/esm-framework@next
 
 Vérifiez que vous avez la dernière version du framework en lançant:
 
-```sh yarn up openmrs@next @openmrs/esm-framework@next
-
+```sh 
+yarn up openmrs@next @openmrs/esm-framework@next
 ```
 
 ```sh


### PR DESCRIPTION
Updates the migration guide to include an extra step related to reducing the number of Webpack chunks created, which in effect reduces the number of JavaScript files that get loaded at runtime. 