### PR TITLE
Add note on how config properties for modules get loaded on demand

### DIFF
--- a/pages/docs/configure-o3/overview.en-US.mdx
+++ b/pages/docs/configure-o3/overview.en-US.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Overview
 
 There are various approaches implementers can use to configure their O3 instances. These include:
@@ -29,6 +31,12 @@ Per-app configuration is available in O3 via the built-in [configuration system]
 Implementers can make changes to frontend module configurations through the built-in implementer tools panel. Once you log into O3, clicking the caret arrow centered at the bottom of the screen will pull up the implementer tools. Alternatively, you can click on the cog icon in the navbar. Once open, you can look up configuration properties by searching through the configuration and modify them on the fly. Note that any tweaks made to the configuration through the implementer tools will be lost once you refresh the page. To make permanent changes to the configuration, you will need to commit those changes to your distro's configuration. The implementer tools allow you to download a temporary config file containing your changes by clicking the `Download config` button.
 
 Typically, you're going to need to make multiple configuration overrides to various frontend modules. The canonical way to do this is to create a JSON configuration file that lives on your server. You can then point your SPA to this configuration file by specifying its URL in the SPA build configuration file. An example of such a config file is the [Ozone Cambodia config file](https://github.com/openmrs/ozone-distro-cambodia/blob/main/configs/openmrs/frontend_config/ozone-frontend-config.json). Each key in the config file corresponds to a frontend module. The value of each key is an object containing the configuration properties that you want to override for that module. These properties correspond to whatever properties are defined in the module's config schema.
+
+  <Callout emoji="ℹ️" type="info">
+    O3 loads frontend modules on demand. This means you'll only see a module's configuration properties in the implementer tools if the module itself has been loaded. If you're only seeing default keys like "Display conditions" and "Translation overrides" in a module config schema in the implementer tools, it means the relevant module likely hasn't loaded yet.
+
+    To view configuration for modules related to a specific feature, like the order basket, navigate to that section of the application (e.g., the Patient Chart). Once the module loads, you'll see all its configurable properties in the implementer tools.
+  </Callout>
 
 ## Distro-level configuration
 

--- a/pages/docs/configure-o3/overview.fr-FR.mdx
+++ b/pages/docs/configure-o3/overview.fr-FR.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Aperçu
 
 Il existe diverses approches que les implémenteurs peuvent utiliser pour configurer leurs instances O3. Celles-ci incluent:
@@ -39,6 +41,12 @@ Notez que toute modification apportée à la configuration via les outils de l'i
 Généralement, vous devrez apporter plusieurs substitutions de configuration à divers modules frontend différents. La façon canonique de faire cela est de créer un fichier de configuration JSON qui réside sur votre serveur. Vous pouvez alors pointer votre SPA vers ce fichier de configuration en spécifiant son URL dans le fichier de configuration de génération de la SPA. Un exemple d'un tel fichier de configuration est le [fichier de configuration Ozone Cambodia](https://github.com/openmrs/ozone-distro-cambodia/blob/main/configs/openmrs/frontend_config/ozone-frontend-config.json). 
 
 Chaque clé dans le fichier de configuration correspond à un module frontend. La valeur de chaque clé est un objet contenant les propriétés de configuration que vous souhaitez substituer pour ce module. Ces propriétés correspondent aux propriétés définies dans le schéma de configuration du module.
+
+<Callout emoji="ℹ️" type="info">
+    O3 charge les modules frontend à la demande. Cela signifie que vous ne verrez les propriétés de configuration d'un module dans les outils de mise en œuvre que si le module lui-même a été chargé. Si vous ne voyez que des clés par défaut comme "Display conditions" et "Translation overrides" dans un schéma de configuration de module dans les outils de mise en œuvre, cela signifie que le module concerné n'a probablement pas encore été chargé.
+
+    Pour voir la configuration des modules liés à une fonctionnalité spécifique, comme le panier de commandes, naviguez vers cette section de l'application (par exemple, le Dossier Patient). Une fois le module chargé, vous verrez toutes ses propriétés configurables dans les outils de mise en œuvre.
+</Callout>
 
 ## Configuration au niveau de la distribution
 


### PR DESCRIPTION
This answers a question I've been getting recently on why a frontend module's configuration properties don't always appear in the implementer tools.

For example, these are the available properties for the `orders` app while on the home page:

![CleanShot 2024-03-25 at 6  44 55@2x](https://github.com/denniskigen/o3-docs/assets/8509731/4c996a97-2969-4977-b555-125285d4098a)

Versus what you see after landing on a Patient Chart:

![CleanShot 2024-03-25 at 6  45 17@2x](https://github.com/denniskigen/o3-docs/assets/8509731/1f62c9dc-25cb-4e3f-aad6-f8ba6ce0f6a6)

Note how the `orderEncounterType` property appears once the module gets loaded.
