### PR TITLE
Improve the O3 Docker setup recipe

### DIFF
--- a/pages/docs/recipes/set-up-o3-instance.en-US.mdx
+++ b/pages/docs/recipes/set-up-o3-instance.en-US.mdx
@@ -129,15 +129,28 @@ This command does the following:
 
 ### Step 4
 
-At this point, you should be able to launch O3 by visiting `http://localhost/openmrs` in your browser. If you're not using a browser, you can curl the URL to see if the server is running:
+At this point, the backend setup script should be running. If you're
+using a browser, navigating to `localhost/openmrs` should redirect you to the initial setup page at `localhost/openmrs/initialsetup`. This setup will take a few minutes to complete. Once it's done, you should be able to launch O3 by visiting `http://localhost/openmrs` in your browser. If you're not using a browser, you can curl the URL to see check whether the setup is complete. Run the following command in your terminal to do this:
 
 ```sh
 curl -v http://localhost/openmrs
 ```
 
-You'll either see the legacy OpenMRS UI or the initial setup screen, depending on whether the backend has been set up.
+If you see `200 OK` in the response, the setup should be complete. You could also use curl to check whether the OpenMRS health check endpoint is up and running using:
 
-To launch the SPA, visit `http://localhost/openmrs/spa`. That's it! You should now have a running instance of O3.
+```sh
+curl -v http://localhost/openmrs/health/started
+```
+
+Alternatively, you can run this script in your terminal to check whether O3 is up and running.
+
+```sh
+ while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+```
+
+This script will check the status of the server every 10 seconds until the server is up and running.
+
+Once the server is up and running, visit `http://localhost/openmrs/spa` and you'll be redirected to the login page. That's it! You should now have a running instance of O3.
 
 ### Step 5 (optional)
 

--- a/pages/docs/recipes/set-up-o3-instance.fr-FR.mdx
+++ b/pages/docs/recipes/set-up-o3-instance.fr-FR.mdx
@@ -128,15 +128,27 @@ Cette commande fait les actions suivantes:
 
 ### Étape 4
 
-À ce stade, vous devriez pouvoir lancer O3 en visitant `http://localhost/openmrs` dans votre navigateur. Si vous n'utilisez pas de navigateur, vous pouvez utiliser curl pour voir si le serveur fonctionne:
+À ce stade, le script de configuration du backend devrait être en cours d'exécution. Si vous utilisez un navigateur, accéder à localhost/openmrs devrait vous rediriger vers la page de configuration initiale à localhost/openmrs/initialsetup. Cette configuration prendra quelques minutes. Une fois terminée, vous devriez pouvoir lancer O3 en visitant http://localhost/openmrs dans votre navigateur. Si vous n'utilisez pas de navigateur, vous pouvez utiliser curl pour vérifier si la configuration est terminée. Exécutez la commande suivante dans votre terminal pour ce faire:
 
 ```sh
 curl -v http://localhost/openmrs
 ```
 
-Vous verrez soit l'interface utilisateur héritée d'OpenMRS, soit l'écran de configuration initiale, selon que le backend a été configuré.
+Si vous voyez `200 OK` dans la réponse, la configuration devrait être terminée. Vous pouvez également utiliser curl pour vérifier si le point de contrôle de santé d'OpenMRS est opérationnel en utilisant:
 
-Pour lancer le SPA, visitez `http://localhost/openmrs/spa`. C'est tout! Vous devriez maintenant avoir une instance de O3 en cours d'exécution.
+```sh
+curl -v http://localhost/openmrs/health/started
+```
+
+Vous pouvez également exécuter ce script dans votre terminal pour vérifier si O3 est opérationnel.
+
+```sh
+ while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+```
+
+Ce script vérifiera le statut du serveur toutes les 10 secondes jusqu'à ce que le serveur soit opérationnel.
+
+Une fois le serveur opérationnel, visitez http://localhost/openmrs/spa et vous serez redirigé vers la page de connexion. Voilà! Vous devriez maintenant avoir une instance de O3 en cours d'exécution.
 
 ### Étape 5 (optionnelle)
 


### PR DESCRIPTION
Adds more guidance around how to check for whether the O3 server is up and running when setting up and instance using Docker.