### PR TITLE
Fix incorrect command for running E2E tests 

### DIFF
--- a/pages/docs/frontend-modules/end-to-end-testing.en-US.mdx
+++ b/pages/docs/frontend-modules/end-to-end-testing.en-US.mdx
@@ -114,7 +114,7 @@ export E2E_BASE_URL=http://localhost:8080
 ### Run the tests in [headed](https://playwright.dev/docs/ci#running-headed) and [UI](https://playwright.dev/docs/test-ui-mode) modes:
 
 ```sh
-yarn test-e2e ---headed --ui
+yarn test-e2e --headed --ui
 ```
 
 To run a single test file, pass in the name of the test file that you want to run:

--- a/pages/docs/frontend-modules/end-to-end-testing.fr-FR.mdx
+++ b/pages/docs/frontend-modules/end-to-end-testing.fr-FR.mdx
@@ -116,7 +116,7 @@ export E2E_BASE_URL=http://localhost:8080
 ## Exécuter les tests en modes [headed](https://playwright.dev/docs/ci#running-headed) et [UI](https://playwright.dev/docs/test-ui-mode) :
 
 ```sh
-yarn test-e2e ---headed --ui
+yarn test-e2e --headed --ui
 ```
 
 Pour exécuter un seul fichier de test, passez le nom du fichier de test que vous souhaitez exécuter :


### PR DESCRIPTION
This PR fixes the docs for the incorrect command for running E2E tests.

<img width="1044" alt="Screenshot 2024-12-02 at 22 20 47" src="https://github.com/user-attachments/assets/0b7be6f7-11b2-46e5-b94a-a97e15880f2c">


